### PR TITLE
feat: Implementar cálculo dinámico del puntaje de neutralidad

### DIFF
--- a/src/app/results/[id]/ResultsScreen.tsx
+++ b/src/app/results/[id]/ResultsScreen.tsx
@@ -38,15 +38,19 @@ type Averages = {
   latency: number;
 };
 
-// El componente ahora recibe los resultados como una prop 'initialResults' y los promedios
+// El componente ahora recibe los resultados como una prop 'initialResults' y los promedios, puntaje y estado de neutralidad
 export function ResultsScreen({ 
   initialResults, 
   cityAverages, 
-  ispAverages 
+  ispAverages, 
+  neutralityScore, 
+  neutralityStatus
 }: { 
   initialResults: TestResult; 
   cityAverages: Averages;
   ispAverages: Averages;
+  neutralityScore: number;
+  neutralityStatus: string;
 }) {
   // Usar los datos reales de la base de datos
   const results = {
@@ -57,8 +61,8 @@ export function ResultsScreen({
     city: initialResults.city,
     jitter: initialResults.jitter,
     testDate: initialResults.testDate,
-    neutralityStatus: "good", // Simplificado por ahora
-    neutralityScore: 92, // Simplificado por ahora
+neutralityStatus,
+neutralityScore
   }
 
   // Usar los promedios reales calculados desde la base de datos
@@ -66,6 +70,19 @@ export function ResultsScreen({
   const ispAverage = ispAverages;
 
   const getNeutralityStatus = () => {
+    // Manejar el caso cuando no hay datos suficientes
+    if (results.neutralityStatus === 'insufficient-data') {
+      return {
+        status: "Datos insuficientes para el análisis",
+        description: "No hay suficientes datos de comparación para tu ISP o ciudad. Sé el primero en contribuir.",
+        color: "text-gray-700",
+        bgColor: "bg-gray-50",
+        borderColor: "border-gray-200",
+        icon: AlertTriangle,
+        iconColor: "text-gray-600",
+      }
+    }
+    
     if (results.neutralityScore >= 85) {
       return {
         status: "No detectamos anomalías significativas",

--- a/src/app/results/[id]/page.tsx
+++ b/src/app/results/[id]/page.tsx
@@ -44,6 +44,48 @@ async function calculateIspAverages(isp: string) {
   return { download, upload, latency };
 }
 
+// Función para calcular el puntaje de neutralidad
+function calculateNeutralityScore(
+  testResult: any,
+  ispAverages: { download: number; upload: number; latency: number },
+  cityAverages: { download: number; upload: number; latency: number }
+) {
+  // Si no hay promedios disponibles, devolver valores por defecto
+  if (ispAverages.download === 0 || ispAverages.upload === 0) {
+    return { score: 0, status: 'insufficient-data' };
+  }
+
+  // Calcular el ratio de velocidad comparado con el ISP
+  const downloadRatio = testResult.downloadSpeed / ispAverages.download;
+  const uploadRatio = testResult.uploadSpeed / ispAverages.upload;
+  
+  // Para la latencia, un valor más bajo es mejor, así que invertimos el ratio
+  const latencyRatio = ispAverages.latency > 0 ? ispAverages.latency / testResult.ping : 1;
+
+  // Calcular el puntaje promedio ponderado
+  // Damos más peso a la descarga (50%), luego subida (30%) y latencia (20%)
+  const weightedScore = (
+    (downloadRatio * 0.5) +
+    (uploadRatio * 0.3) +
+    (latencyRatio * 0.2)
+  ) * 100;
+
+  // Limitar el puntaje entre 0 y 100
+  const score = Math.min(100, Math.max(0, Math.round(weightedScore)));
+
+  // Determinar el estado basado en el puntaje
+  let status: string;
+  if (score >= 85) {
+    status = 'neutral';
+  } else if (score >= 70) {
+    status = 'possible-throttling';
+  } else {
+    status = 'throttling-detected';
+  }
+
+  return { score, status };
+}
+
 // Este es el componente de la página principal
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -53,6 +95,17 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   const cityAverages = await calculateCityAverages(resultData.city);
   const ispAverages = await calculateIspAverages(resultData.isp);
 
+  // Calcular el puntaje de neutralidad
+  const neutralityData = calculateNeutralityScore(resultData, ispAverages, cityAverages);
+
   // Pasamos los datos del servidor a un componente de cliente para la interactividad
-  return <ResultsScreen initialResults={resultData} cityAverages={cityAverages} ispAverages={ispAverages} />;
+  return (
+    <ResultsScreen 
+      initialResults={resultData} 
+      cityAverages={cityAverages} 
+      ispAverages={ispAverages}
+      neutralityScore={neutralityData.score}
+      neutralityStatus={neutralityData.status}
+    />
+  );
 }


### PR DESCRIPTION
- Añadir función calculateNeutralityScore con algoritmo ponderado
- Calcular puntaje basado en ratios de velocidad vs promedios del ISP
- Implementar umbrales de estado (neutral: >=85, posible throttling: 70-84, throttling detectado: <70)
- Actualizar ResultsScreen para mostrar puntaje y estado dinámicamente
- Manejar caso de datos insuficientes con mensaje apropiado